### PR TITLE
Add PDF Export feature

### DIFF
--- a/data/kendo-ui-angular.yml
+++ b/data/kendo-ui-angular.yml
@@ -30,6 +30,7 @@ features:
   maintained: true
   openSource: false
   pagination: true
+  pdfExport: true
   pivots: false
   rangeSelection: false
   resizableCols: true

--- a/data/kendo-ui-vue.yml
+++ b/data/kendo-ui-vue.yml
@@ -30,6 +30,7 @@ features:
   maintained: true
   openSource: false
   pagination: true
+  pdfExport: true
   pivots: false
   rangeSelection: false
   resizableCols: true

--- a/data/kendoreact-data-grid.yml
+++ b/data/kendoreact-data-grid.yml
@@ -30,6 +30,7 @@ features:
   maintained: true
   openSource: false
   pagination: true
+  pdfExport: true
   pivots: false
   rangeSelection: false
   resizableCols: true

--- a/data/syncfusion-datagrid.yml
+++ b/data/syncfusion-datagrid.yml
@@ -32,6 +32,7 @@ features:
   maintained: true
   openSource: true
   pagination: true
+  pdfExport: true
   pivots: false
   rangeSelection: false
   resizableCols: true

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -86,6 +86,11 @@ export const Features = {
     description:
       'Supports a widget to navigate through pages of rows as opposed to scrolling.',
   },
+  pdfExport: {
+    title: 'PDF Export',
+    description:
+      'The library lets you download a PDF copy of the table contents without third-party libraries.',
+  },
   pivots: {
     title: 'Pivot Tables',
     description: 'Has support for pivot tables',


### PR DESCRIPTION
That's a bit of an unusual feature for a data table, but the Kendo UI and Syncfusion grids support it. Maybe it makes sense to be listed as a feature to make it more discoverable.