### PR TITLE
Adds DataGridXL

### DIFF
--- a/data/datagridxl.yml
+++ b/data/datagridxl.yml
@@ -1,0 +1,44 @@
+title: DataGridXL
+homeUrl: https://datagridxl.com
+demoUrl: https://datagridxl.com/demos
+githubRepo: datagridxl/datagridxl
+npmPackage: null
+license: Custom License
+revenueModel: Free for Personal Use
+description: >
+  No-nonsense Super Fast Excel-like Data Grid Library (Up to 1 Million Cells).
+frameworks:
+  angular: false
+  react: true
+  vanilla: true
+  vue: true
+features:
+  accessible: false
+  copyPaste: true
+  csvExport: true
+  customEditors: false
+  customFormatters: false
+  draggableRows: true
+  editable: true
+  fillDown: true
+  fillRight: true
+  filtering: false
+  formulas: false
+  freezableCols: false
+  headless: false
+  i18n: true
+  maintained: true
+  openSource: false
+  pagination: false
+  pdfExport: false
+  pivots: false
+  rangeSelection: true
+  resizableCols: true
+  responsive: true
+  rowGrouping: false
+  rowSelection: true
+  serverSide: false
+  sorting: true
+  trees: false
+  xlsxExport: false
+  virtualization: true


### PR DESCRIPTION
A request to add DataGridXL: the no-nonsense fast Excel-like data table library. (https://datagridxl.com)