### PR TITLE
Update glide-data-grid.yml

### DIFF
--- a/data/glide-data-grid.yml
+++ b/data/glide-data-grid.yml
@@ -35,6 +35,7 @@ features:
   responsive: true
   rowGrouping: false
   rowSelection: true
+  search: true
   serverSide: true
   sorting: true
   trees: false


### PR DESCRIPTION
Glide Data Grid has built in search. Demo here: https://quicktype.github.io/glide-data-grid/?path=/story/glide-data-grid-dataeditor-demos--built-in-search

Technically the grid also allows for filtering but its not as built in so I wont push for that.