### PR TITLE
Add bilig

### DIFF
--- a/data/bilig.yml
+++ b/data/bilig.yml
@@ -14,7 +14,7 @@ frameworks:
   vanilla: true
 features:
   accessible: UI accessibility is up to the embedding application.
-  copyPaste: false
+  copyPaste: Programmatic range copy and paste; no browser clipboard UI.
   csvExport: false
   customEditors: false
   customFormatters: false
@@ -22,17 +22,17 @@ features:
   editable: true
   fillDown: false
   fillRight: false
-  filtering: Metadata support; UI behavior is up to the embedding application.
+  filtering: false
   formulas: true
   freezableCols: false
   headless: true
-  i18n: true
+  i18n: false
   maintained: true
-  mergeCells: Metadata support; UI behavior is up to the embedding application.
+  mergeCells: false
   openSource: true
   pagination: false
   pdfExport: false
-  pivots: Formula support includes PIVOTBY; visual pivot table UI is not included.
+  pivots: false
   rangeSelection: false
   resizableCols: false
   responsive: UI layout is up to the embedding application.
@@ -41,7 +41,7 @@ features:
   rowSelection: false
   search: false
   serverSide: true
-  sorting: Metadata and formula support; UI behavior is up to the embedding application.
+  sorting: false
   sparklines: false
   theming: false
   trees: false

--- a/data/bilig.yml
+++ b/data/bilig.yml
@@ -1,0 +1,50 @@
+title: bilig
+homeUrl: https://proompteng.github.io/bilig/
+demoUrl: https://github.com/proompteng/bilig/tree/main/examples/headless-workpaper
+githubRepo: proompteng/bilig
+npmPackage: "@bilig/headless"
+license: MIT License
+revenueModel: Free
+description: >
+  bilig is a headless TypeScript spreadsheet engine and WorkPaper API for Node
+  services, coding agents, and server-side workbook automation. It supports
+  formula-backed workbooks, structural edits, persistence round trips,
+  validation, and readback without opening a browser grid.
+frameworks:
+  vanilla: true
+features:
+  accessible: UI accessibility is up to the embedding application.
+  copyPaste: false
+  csvExport: false
+  customEditors: false
+  customFormatters: false
+  draggableRows: false
+  editable: true
+  fillDown: false
+  fillRight: false
+  filtering: Metadata support; UI behavior is up to the embedding application.
+  formulas: true
+  freezableCols: false
+  headless: true
+  i18n: true
+  maintained: true
+  mergeCells: Metadata support; UI behavior is up to the embedding application.
+  openSource: true
+  pagination: false
+  pdfExport: false
+  pivots: Formula support includes PIVOTBY; visual pivot table UI is not included.
+  rangeSelection: false
+  resizableCols: false
+  responsive: UI layout is up to the embedding application.
+  rowGrouping: false
+  rowPinning: false
+  rowSelection: false
+  search: false
+  serverSide: true
+  sorting: Metadata and formula support; UI behavior is up to the embedding application.
+  sparklines: false
+  theming: false
+  trees: false
+  typescript: true
+  xlsxExport: false
+  virtualization: false


### PR DESCRIPTION
Adds bilig, a headless TypeScript spreadsheet engine for Node services and coding agents.

Notes:
- public repo: https://github.com/proompteng/bilig
- npm package: @bilig/headless
- this is listed as headless and vanilla because it exposes workbook/formula logic without a bundled UI

I kept UI-specific features false unless the package exposes the behavior directly.