### PR TITLE
Add react-datatable to curated library directory

### DIFF
--- a/data/react-datatable.yml
+++ b/data/react-datatable.yml
@@ -16,12 +16,12 @@ frameworks:
   react: true
 features:
   accessible: true
-  copyPaste: false
-  csvExport: false
+  copyPaste: Adding copy and paste is up to you in your shipped source.
+  csvExport: Adding CSV export is up to you in your shipped source.
   customEditors: true
   customFormatters: true
   draggableRows: false
-  editable: false
+  editable: Adding editable cells is up to you in your shipped source.
   fillDown: false
   fillRight: false
   filtering: true
@@ -48,5 +48,5 @@ features:
   theming: true
   trees: false
   typescript: true
-  xlsxExport: false
+  xlsxExport: Adding XLSX export is up to you in your shipped source.
   virtualization: true

--- a/data/react-datatable.yml
+++ b/data/react-datatable.yml
@@ -1,7 +1,7 @@
 title: react-datatable
 homeUrl: https://react-datatable.com/
-demoUrl: https://react-datatable.com/#showcase
-githubRepo: FroeMic/react-datatable
+demoUrl: https://react-datatable.com/docs
+githubRepo: null
 npmPackage: null
 license: Custom License
 revenueModel: Commercial with Trial
@@ -31,7 +31,7 @@ features:
   i18n: false
   maintained: true
   mergeCells: false
-  openSource: true
+  openSource: false
   pagination: true
   pdfExport: false
   pivots: false

--- a/data/react-datatable.yml
+++ b/data/react-datatable.yml
@@ -1,0 +1,52 @@
+title: react-datatable
+homeUrl: https://react-datatable.com/
+demoUrl: https://react-datatable.com/#showcase
+githubRepo: FroeMic/react-datatable
+npmPackage: null
+license: Custom License
+revenueModel: Commercial with Trial
+description: >
+  Source-first React datatable kit built on TanStack Table with shadcn-style
+  Radix primitives and Tailwind. Ships an integrated product surface—global
+  search, column filters, multi-sort, grouping, row selection, bulk actions,
+  saved views, URL state, local and server-backed loading (pagination and
+  infinite scroll), and row/column virtualization with frozen columns—meant to
+  be copied into your app so you own and customize the UI.
+frameworks:
+  react: true
+features:
+  accessible: true
+  copyPaste: false
+  csvExport: false
+  customEditors: true
+  customFormatters: true
+  draggableRows: false
+  editable: false
+  fillDown: false
+  fillRight: false
+  filtering: true
+  formulas: false
+  freezableCols: true
+  headless: false
+  i18n: false
+  maintained: true
+  mergeCells: false
+  openSource: true
+  pagination: true
+  pdfExport: false
+  pivots: false
+  rangeSelection: false
+  resizableCols: true
+  responsive: true
+  rowGrouping: true
+  rowPinning: false
+  rowSelection: true
+  search: true
+  serverSide: true
+  sorting: true
+  sparklines: false
+  theming: true
+  trees: false
+  typescript: true
+  xlsxExport: false
+  virtualization: true


### PR DESCRIPTION
Adds `data/react-datatable.yml` for [react-datatable](https://react-datatable.com/) ([docs](https://react-datatable.com/docs?utm_source=github&utm_medium=pr&utm_campaign=3rdcom265)). Commercial, source-licensed product—`githubRepo` is null and `openSource` is false so the directory does not imply a public repository.