### PR TITLE
Add xexcel

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [Webix Grid](https://grid.webix.com) - A JavaScript data grid with a rich API and extensive customization options.
 - [Wijmo FlexGrid](https://www.grapecity.com/wijmo/flexgrid-javascript-data-grid) - A JavaScript data grid component with editing, sorting, filtering, grouping, and Excel-style features, with support for major frameworks.
 - [Wijmo Grid](https://www.grapecity.com/wijmo) - Enterprise-grade JavaScript data grid component by GrapeCity.
+- [xexcel](https://ximing.github.io/xexcel/) - An embeddable Excel-style spreadsheet with a State, Transaction, and Plugin architecture, a formula engine, and xlsx/CSV interoperability.
 - [ZingGrid](https://www.zinggrid.com/) - A JavaScript Web Component data grid and table library built with ES6 and native web components.
 
 ## Motivation

--- a/data/xexcel.yml
+++ b/data/xexcel.yml
@@ -1,0 +1,51 @@
+title: xexcel
+homeUrl: https://ximing.github.io/xexcel/
+demoUrl: https://ximing.github.io/xexcel/
+githubRepo: ximing/xexcel
+npmPackage: "@xexcel/react"
+license: MIT License
+revenueModel: Free
+description: >
+  An embeddable Excel-style spreadsheet with a State, Transaction, and
+  Plugin architecture (inspired by ProseMirror). It ships a DOM-free formula
+  engine, xlsx/CSV import and export, multi-sheet workbooks, and a React
+  shell that drops in as <ExcelEditor/>.
+frameworks:
+  react: true
+  vanilla: true
+features:
+  accessible: false
+  copyPaste: true
+  csvExport: true
+  customEditors: false
+  customFormatters: true
+  draggableRows: false
+  editable: true
+  fillDown: true
+  fillRight: true
+  filtering: true
+  formulas: true
+  freezableCols: true
+  headless: false
+  i18n: true
+  maintained: true
+  mergeCells: true
+  openSource: true
+  pagination: false
+  pdfExport: false
+  pivots: false
+  rangeSelection: true
+  resizableCols: true
+  responsive: false
+  rowGrouping: false
+  rowPinning: false
+  rowSelection: true
+  search: true
+  serverSide: false
+  sorting: true
+  sparklines: false
+  theming: false
+  trees: false
+  typescript: true
+  xlsxExport: true
+  virtualization: true


### PR DESCRIPTION
## What

Add [xexcel](https://github.com/ximing/xexcel) to the library list.

- Demo: https://ximing.github.io/xexcel/
- npm: `@xexcel/react` / `@xexcel/core` / `@xexcel/view`
- License: MIT

Embeddable Excel-style spreadsheet: State + Transaction + Plugin kernel, formula engine, xlsx/CSV, React shell.

## Checklist

- [x] YAML in `data/xexcel.yml` using the existing feature flags
- [x] README entry, alphabetical, sentence case, ends with a period
- [x] Description adapted from the project README

I did not run `npx awesome-lint` in this environment; happy to fix if CI flags anything.