### PR TITLE
Add snowtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 - [shadcn/ui Data Table](https://ui.shadcn.com/docs/components/data-table) - Powerful table and datagrids built using TanStack Table with shadcn/ui components.
 - [SlickGrid](https://slickgrid.net/) - An open-source, client-side JavaScript grid control that binds to an external data source and is compatible with a wide range of data-centric frameworks.
 - [Smart.Grid](https://www.htmlelements.com/docs/grid/) - A Data Grid component which displays tabular data.
+- [snowtable](https://github.com/snowpact/snowtable) - Ultra-light React data table wrapping TanStack Table and TanStack Query behind a uniform client/server API.
 - [SpreadJS](https://developer.mescius.com/spreadjs) - An Excel-like JavaScript spreadsheet component with no dependency on Excel, for building financial, scientific, and business applications.
 - [SVAR DataGrid](https://svar.dev/svelte/datagrid/) - A lightweight data grid component for Svelte and React with in-cell editing, sorting, filtering, virtual scrolling, pagination, and keyboard navigation.
 - [SvGrid](https://svgrid.com) - A headless-first, Svelte 5-native data grid with a batteries-included render component, offering in-cell editing, sorting, filtering, virtualization, row grouping, and tree data, with pivots and Excel/PDF export in a paid Pro pack.

--- a/data/snowtable.yml
+++ b/data/snowtable.yml
@@ -1,0 +1,44 @@
+title: snowtable
+homeUrl: https://github.com/snowpact/snowtable
+demoUrl: https://snowpact.github.io/snowtable/
+githubRepo: snowpact/snowtable
+npmPackage: "@snowpact/snowtable"
+license: MIT License
+revenueModel: Free
+description: >
+  Ultra-light, registry-based React data table wrapping TanStack Table and
+  TanStack Query behind a uniform client/server API.
+frameworks:
+  react: true
+features:
+  accessible: false
+  copyPaste: false
+  csvExport: false
+  customEditors: false
+  customFormatters: true
+  draggableRows: false
+  editable: false
+  fillDown: false
+  fillRight: false
+  filtering: true
+  formulas: false
+  freezableCols: false
+  headless: false
+  i18n: true
+  maintained: true
+  mergeCells: false
+  openSource: true
+  pagination: true
+  pdfExport: false
+  pivots: false
+  rangeSelection: false
+  resizableCols: false
+  responsive: true
+  rowGrouping: false
+  rowSelection: false
+  serverSide: true
+  sorting: true
+  trees: false
+  typescript: true
+  xlsxExport: false
+  virtualization: false


### PR DESCRIPTION
Adds **snowtable** to the Libraries list (alphabetical, between `Smart.Grid` and `SpreadJS`), plus its `data/snowtable.yml` for the interactive site.

Ultra-light (~60 KB), MIT React data table that wraps **TanStack Table** with **TanStack Query** behind a uniform client/server API (registry-based setup for Link / i18n / styles). Built-in filtering, sorting, pagination, server mode, and responsive card mode.

- Repo: https://github.com/snowpact/snowtable
- Demo: https://snowpact.github.io/snowtable/

Feature flags in the YAML are set conservatively (no virtualization / inline editing / export). _Disclosure: I'm the maintainer_ — happy to adjust flags or wording, or drop it if it's out of scope. Thanks for maintaining this list! 🙏
